### PR TITLE
Adds commands for changing channel and sending named commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Some other commands you can invoke via command line:
         --harmony_ip my_hub_host send_command --device 'yamaha soundbar' \
         --command PowerToggle
 
+    PYTHONPATH="." python harmony --email user@example.com --password pass \
+        --harmony_ip my_hub_host change_channel 123
+
 For full argument information on the command-line tool:
 
     PYTHONPATH="." python harmony --help

--- a/README.md
+++ b/README.md
@@ -42,16 +42,13 @@ Some other commands you can invoke via command line:
         --harmony_ip my_hub_host turn_off
 
     # to send device commands, look in show_config for the device and
-    # command name, you can use either the device id or label with --device
+    # command name, you can use either the device id or label with --device.
+    # If device is not included, function searches for the command name within
+    # the current activity.
     #
     PYTHONPATH="." python harmony --email user@example.com --password pass \
         --harmony_ip my_hub_host send_command --device 'yamaha soundbar' \
-        --command PowerToggle
-
-    # to send commands named in the activity (usually [always?] button
-    # assignments). x=number of times to repeat the action
-    PYTHONPATH="." python harmony --email user@example.com --password pass \
-        --harmony_ip my_hub_host send_command_named "command name" x
+        --command PowerToggle --repeat x
 
     PYTHONPATH="." python harmony --email user@example.com --password pass \
         --harmony_ip my_hub_host change_channel 123

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ Some other commands you can invoke via command line:
         --harmony_ip my_hub_host send_command --device 'yamaha soundbar' \
         --command PowerToggle
 
+    # to send commands named in the activity (usually [always?] button
+    # assignments). x=number of times to repeat the action
+    PYTHONPATH="." python harmony --email user@example.com --password pass \
+        --harmony_ip my_hub_host send_command_named "command name" x
+
     PYTHONPATH="." python harmony --email user@example.com --password pass \
         --harmony_ip my_hub_host change_channel 123
 

--- a/harmony/__main__.py
+++ b/harmony/__main__.py
@@ -150,6 +150,12 @@ def send_command(args):
     client.disconnect(send_close=True)
     return 0
 
+def change_channel(args):
+    """Connects to the Harmony and changes channel."""
+    client = get_client(args)
+    client.change_channel(args.channel)
+    return 0
+
 def main():
     """Main method for the script."""
     parser = argparse.ArgumentParser(
@@ -217,6 +223,14 @@ def main():
         help='Specify the device id or label to which we will send the command.')
 
     command_parser.set_defaults(func=send_command)
+
+    change_channel_parser = subparsers.add_parser(
+        'change_channel', help='Change the channel.')
+
+    change_channel_parser.add_argument(
+        'channel', help='Specify the channel to send to the harmony.')
+
+    change_channel_parser.set_defaults(func=change_channel)
 
     args = parser.parse_args()
 

--- a/harmony/__main__.py
+++ b/harmony/__main__.py
@@ -62,7 +62,7 @@ def show_current_activity(args):
     pprint(activity)
 
     client.disconnect(send_close=True)
-    return 0
+    return activity
 
 def sync(args):
     """Connects to the Harmony and syncs it.
@@ -159,8 +159,7 @@ def change_channel(args):
 def send_command_named(args):
     client=get_client(args)
     vactivity=show_current_activity(args)
-    with open("data.json",'w') as outfile:
-        json.dump(vactivity,outfile)
+
     for x in vactivity['controlGroup']:
         for y in x['function']:
             z=y['label']

--- a/harmony/__main__.py
+++ b/harmony/__main__.py
@@ -156,6 +156,23 @@ def change_channel(args):
     client.change_channel(args.channel)
     return 0
 
+def send_command_named(args):
+    client=get_client(args)
+    vactivity=show_current_activity(args)
+    with open("data.json",'w') as outfile:
+        json.dump(vactivity,outfile)
+    for x in vactivity['controlGroup']:
+        for y in x['function']:
+            z=y['label']
+            zz=json.loads(y['action'])
+            if z.replace(" ","").lower()==args.command.replace(" ","").lower():
+                args.device_id=zz['deviceId']
+                args.command=zz['command']
+                for zzz in range (0,int(args.repeat)):
+                    send_command(args)
+    client.disconnect(send_close=True)
+    return 0
+
 def main():
     """Main method for the script."""
     parser = argparse.ArgumentParser(
@@ -231,6 +248,18 @@ def main():
         'channel', help='Specify the channel to send to the harmony.')
 
     change_channel_parser.set_defaults(func=change_channel)
+
+    """Send_Command_named"""
+    named_parser = subparsers.add_parser(
+        'send_command_named', help='Send a generic command.')
+
+    named_parser.add_argument('command',
+        help='Named command to send to the device.')
+
+    named_parser.add_argument('repeat',
+        help='Number of times to repeat instruction', default=1)
+
+    named_parser.set_defaults(func=send_command_named)
 
     args = parser.parse_args()
 

--- a/harmony/__main__.py
+++ b/harmony/__main__.py
@@ -127,6 +127,9 @@ def send_command(args):
 
     config = client.get_config()
 
+    if args.device is None and args.device_id is None
+        seond_command_named(args)
+
     device = args.device if args.device_id is None else args.device_id
 
     device_numeric = None
@@ -224,13 +227,28 @@ def main():
 
     turn_off_parser.set_defaults(func=turn_off)
 
+    #    """Send_Command_named"""
+    #    named_parser = subparsers.add_parser(
+    #        'send_command_named', help='Send a generic command.')
+    #
+    #    named_parser.add_argument('--command', required=True,
+    #        help='Named command to send to the device.')
+    #
+    #    named_parser.add_argument('--repeat', default=1,
+    #        help='Number of times to repeat instruction')
+    #
+    #    named_parser.set_defaults(func=send_command_named)
+
     command_parser = subparsers.add_parser(
         'send_command', help='Send a simple command.')
 
     command_parser.add_argument('--command',
         help='IR Command to send to the device.', required=True)
 
-    device_arg_group = command_parser.add_mutually_exclusive_group(required=True)
+    commad.parser.add_argument('--repeat', default=1,
+        help='Number of times to repeat command')
+
+    device_arg_group = command_parser.add_mutually_exclusive_group(required=False)
 
     device_arg_group.add_argument('--device_id',
         help='Specify the device id to which we will send the command.')
@@ -247,18 +265,6 @@ def main():
         'channel', help='Specify the channel to send to the harmony.')
 
     change_channel_parser.set_defaults(func=change_channel)
-
-    """Send_Command_named"""
-    named_parser = subparsers.add_parser(
-        'send_command_named', help='Send a generic command.')
-
-    named_parser.add_argument('command',
-        help='Named command to send to the device.')
-
-    named_parser.add_argument('repeat',
-        help='Number of times to repeat instruction', default=1)
-
-    named_parser.set_defaults(func=send_command_named)
 
     args = parser.parse_args()
 

--- a/harmony/__main__.py
+++ b/harmony/__main__.py
@@ -161,7 +161,8 @@ def send_command(args):
 
     device_id = int(device_config[0]['id'])
 
-    client.send_command(device_id, args.command)
+    for zzz in range (0,int(args.repeat)):
+        client.send_command(device_id, args.command)
 
     client.disconnect(send_close=True)
     return 0

--- a/harmony/__main__.py
+++ b/harmony/__main__.py
@@ -125,11 +125,8 @@ def send_command(args):
     """Connects to the Harmony and send a simple command."""
     client = get_client(args)
 
-    vactivity=show_current_activity(args)
-
-    config = client.get_config()
-
-    if args.device is None and args.device_id is None
+    if args.device is None and args.device_id is None:
+        vactivity=show_current_activity(args)
         for x in vactivity['controlGroup']:
             for y in x['function']:
                 z=y['label']
@@ -141,6 +138,8 @@ def send_command(args):
                         send_command(args)
         client.disconnect(send_close=True)
         return 0
+
+    config = client.get_config()
 
     device = args.device if args.device_id is None else args.device_id
 
@@ -241,7 +240,7 @@ def main():
     command_parser.add_argument('--command',
         help='IR Command to send to the device.', required=True)
 
-    commad.parser.add_argument('--repeat', default=1,
+    command_parser.add_argument('--repeat', default=1,
         help='Number of times to repeat command')
 
     device_arg_group = command_parser.add_mutually_exclusive_group(required=False)

--- a/harmony/__main__.py
+++ b/harmony/__main__.py
@@ -125,10 +125,22 @@ def send_command(args):
     """Connects to the Harmony and send a simple command."""
     client = get_client(args)
 
+    vactivity=show_current_activity(args)
+
     config = client.get_config()
 
     if args.device is None and args.device_id is None
-        seond_command_named(args)
+        for x in vactivity['controlGroup']:
+            for y in x['function']:
+                z=y['label']
+                zz=json.loads(y['action'])
+                if z.replace(" ","").lower()==args.command.replace(" ","").lower():
+                    args.device_id=zz['deviceId']
+                    args.command=zz['command']
+                    for zzz in range (0,int(args.repeat)):
+                        send_command(args)
+        client.disconnect(send_close=True)
+        return 0
 
     device = args.device if args.device_id is None else args.device_id
 
@@ -157,22 +169,6 @@ def change_channel(args):
     """Connects to the Harmony and changes channel."""
     client = get_client(args)
     client.change_channel(args.channel)
-    return 0
-
-def send_command_named(args):
-    client=get_client(args)
-    vactivity=show_current_activity(args)
-
-    for x in vactivity['controlGroup']:
-        for y in x['function']:
-            z=y['label']
-            zz=json.loads(y['action'])
-            if z.replace(" ","").lower()==args.command.replace(" ","").lower():
-                args.device_id=zz['deviceId']
-                args.command=zz['command']
-                for zzz in range (0,int(args.repeat)):
-                    send_command(args)
-    client.disconnect(send_close=True)
     return 0
 
 def main():

--- a/harmony/__main__.py
+++ b/harmony/__main__.py
@@ -126,7 +126,9 @@ def send_command(args):
     client = get_client(args)
 
     if args.device is None and args.device_id is None:
-        vactivity=show_current_activity(args)
+        current_activity_id = client.get_current_activity()
+        vactivity = [x for x in config['activity'] if int(x['id']) == current_activity_id][0]
+        #vactivity=show_current_activity(args)
         for x in vactivity['controlGroup']:
             for y in x['function']:
                 z=y['label']

--- a/harmony/__main__.py
+++ b/harmony/__main__.py
@@ -135,7 +135,7 @@ def send_command(args):
                     args.device_id=zz['deviceId']
                     args.command=zz['command']
                     for zzz in range (0,int(args.repeat)):
-                        send_command(args)
+                        client.send_command(args.device_id, args.command)
         client.disconnect(send_close=True)
         return 0
 
@@ -221,18 +221,6 @@ def main():
         'turn_off', help='Send a turn off command to the harmony.')
 
     turn_off_parser.set_defaults(func=turn_off)
-
-    #    """Send_Command_named"""
-    #    named_parser = subparsers.add_parser(
-    #        'send_command_named', help='Send a generic command.')
-    #
-    #    named_parser.add_argument('--command', required=True,
-    #        help='Named command to send to the device.')
-    #
-    #    named_parser.add_argument('--repeat', default=1,
-    #        help='Number of times to repeat instruction')
-    #
-    #    named_parser.set_defaults(func=send_command_named)
 
     command_parser = subparsers.add_parser(
         'send_command', help='Send a simple command.')

--- a/harmony/client.py
+++ b/harmony/client.py
@@ -118,6 +118,26 @@ class HarmonyClient(sleekxmpp.ClientXMPP):
         time.sleep(0.5)
         return True
 
+    def change_channel(self, channel):
+        """Send a channel to the Harmony Hub.
+
+        Args:
+            channel: Channel
+        """
+        iq_cmd=self.Iq()
+        iq_cmd['type']='get'
+        action_cmd = ET.Element('oa')
+        action_cmd.attrib['xmlns'] = 'connect.logitech.com'
+        action_cmd.attrib['mime'] = ('harmony.engine?changeChannel')
+        action_cmd.text = 'channel=' + str(channel) + ':timestamp=0'
+        iq_cmd.set_payload(action_cmd)
+        result=iq_cmd.send(block=True)
+        payload = result.get_payload()
+        assert len(payload)==1
+        action_cmd = payload[0]
+        return True
+
+
     def turn_off(self):
         """Turns the system off if it's on, otherwise it does nothing.
 


### PR DESCRIPTION
Thanks for the great fork. I'm fairly inexperienced with Python so the code might be a little inefficient, but these two commits add change_channel and send_command_named functions.

Change_channel uses the changeChannel call from the Harmony API, while send_command_name uses the show_current_activity and send_command functions to send a "named" command (generally assigned to a remote button) without needing to specify the deviceId.
